### PR TITLE
Add a licenses page

### DIFF
--- a/content/licenses/index.md
+++ b/content/licenses/index.md
@@ -6,7 +6,8 @@ description: Licenses for documentation content
 ## Images
 
 {{< cards >}}
-{{< card link="https://creativecommons.org/licenses/by-sa/4.0/" title="Arduino Nano" subtitle="arduino.cc CC BY-SA 4.0" image="card-images/boards/arduino-nano.png" method="Resize" options="600x q80 webp" >}}
 {{< card link="https://creativecommons.org/licenses/by-sa/4.0/" title="Arduino Mega 2560 Rev3" subtitle="arduino.cc CC BY-SA 4.0" image="card-images/boards/arduino-mega-2560-rev3.png" method="Resize" options="600x q80 webp" >}}
+{{< card link="https://creativecommons.org/licenses/by-sa/4.0/" title="Arduino Nano" subtitle="arduino.cc CC BY-SA 4.0" image="card-images/boards/arduino-nano.png" method="Resize" options="600x q80 webp" >}}
+{{< card link="https://creativecommons.org/licenses/by-sa/4.0/" title="Arduino Pro Micro (16MHz)" subtitle="SparkFun CC BY-SA 4.0" image="card-images/boards/arduino-pro-micro.png" method="Resize" options="600x q80 webp" >}}
 {{< card link="https://creativecommons.org/licenses/by-sa/4.0/" title="Arduino Uno R3" subtitle="arduino.cc CC BY-SA 4.0" image="card-images/boards/arduino-uno.png" method="Resize" options="600x q80 webp" >}}
 {{< /cards >}}

--- a/content/licenses/index.md
+++ b/content/licenses/index.md
@@ -1,0 +1,12 @@
+---
+title: Licenses
+description: Licenses for documentation content
+---
+
+## Images
+
+{{< cards >}}
+{{< card link="https://creativecommons.org/licenses/by-sa/4.0/" title="Arduino Nano" subtitle="arduino.cc CC BY-SA 4.0" image="card-images/boards/arduino-nano.png" method="Resize" options="600x q80 webp" >}}
+{{< card link="https://creativecommons.org/licenses/by-sa/4.0/" title="Arduino Mega 2560 Rev3" subtitle="arduino.cc CC BY-SA 4.0" image="card-images/boards/arduino-mega-2560-rev3.png" method="Resize" options="600x q80 webp" >}}
+{{< card link="https://creativecommons.org/licenses/by-sa/4.0/" title="Arduino Uno R3" subtitle="arduino.cc CC BY-SA 4.0" image="card-images/boards/arduino-uno.png" method="Resize" options="600x q80 webp" >}}
+{{< /cards >}}

--- a/content/licenses/index.md
+++ b/content/licenses/index.md
@@ -10,4 +10,5 @@ description: Licenses for documentation content
 {{< card link="https://creativecommons.org/licenses/by-sa/4.0/" title="Arduino Nano" subtitle="arduino.cc CC BY-SA 4.0" image="card-images/boards/arduino-nano.png" method="Resize" options="600x q80 webp" >}}
 {{< card link="https://creativecommons.org/licenses/by-sa/4.0/" title="Arduino Pro Micro (16MHz)" subtitle="SparkFun CC BY-SA 4.0" image="card-images/boards/arduino-pro-micro.png" method="Resize" options="600x q80 webp" >}}
 {{< card link="https://creativecommons.org/licenses/by-sa/4.0/" title="Arduino Uno R3" subtitle="arduino.cc CC BY-SA 4.0" image="card-images/boards/arduino-uno.png" method="Resize" options="600x q80 webp" >}}
+{{< card link="https://creativecommons.org/licenses/by-sa/4.0/" title="Raspberry Pi Pico 1" subtitle="Raspberry Pi Ltd CC BY-SA 4.0" image="card-images/boards/raspberry-pi-pico.png" method="Resize" options="600x q80 webp" >}}
 {{< /cards >}}

--- a/content/licenses/index.md
+++ b/content/licenses/index.md
@@ -3,7 +3,7 @@ title: Licenses
 description: Licenses for documentation content
 ---
 
-## Images
+## ## Board image licenses
 
 {{< cards >}}
 {{< card link="https://creativecommons.org/licenses/by-sa/4.0/" title="Arduino Mega 2560 Rev3" subtitle="arduino.cc CC BY-SA 4.0" image="card-images/boards/arduino-mega-2560-rev3.png" method="Resize" options="600x q80 webp" >}}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,0 +1,43 @@
+{{- $enableFooterSwitches := .Scratch.Get "enableFooterSwitches" | default false -}}
+{{- $displayThemeToggle := site.Params.theme.displayToggle | default true -}}
+{{- $footerSwitchesVisible := and $enableFooterSwitches (or hugo.IsMultilingual $displayThemeToggle) -}}
+{{- $copyrightSectionVisible := or (.Site.Params.footer.displayPoweredBy | default true) .Site.Params.footer.displayCopyright -}}
+
+{{- $copyright := (T "copyright") | default "© 2024 Hextra." -}}
+{{- $poweredBy := (T "poweredBy") | default "Powered by Hextra" -}}
+
+{{- $footerWidth := "hx-max-w-screen-xl" -}}
+{{- with .Site.Params.footer.width -}}
+  {{ if eq . "wide" -}}
+    {{ $footerWidth = "hx-max-w-[90rem]" -}}
+  {{ else if eq . "full" -}}
+    {{ $footerWidth = "max-w-full" -}}
+  {{ end -}}
+{{- end -}}
+
+
+<footer class="hextra-footer hx-bg-gray-100 hx-pb-[env(safe-area-inset-bottom)] dark:hx-bg-neutral-900 print:hx-bg-transparent">
+  {{- if $footerSwitchesVisible -}}
+    <div class="hx-mx-auto hx-flex hx-gap-2 hx-py-2 hx-px-4 {{ $footerWidth }}">
+      {{- partial "language-switch.html" (dict "context" .) -}}
+      {{- with $displayThemeToggle }}{{ partial "theme-toggle.html" }}{{ end -}}
+    </div>
+    {{- if or hugo.IsMultilingual $displayThemeToggle -}}
+      <hr class="dark:hx-border-neutral-800" />
+    {{- end -}}
+  {{- end -}}
+    <div
+      class="hextra-custom-footer {{ $footerWidth }} hx-pl-[max(env(safe-area-inset-left),1.5rem)] hx-pr-[max(env(safe-area-inset-right),1.5rem)] hx-text-gray-600 dark:hx-text-gray-400"
+    >
+      {{- partial "custom/footer.html" (dict "context" . "switchesVisible" $footerSwitchesVisible "copyrightVisible" $copyrightSectionVisible) -}}
+    </div>
+    {{- if $copyrightSectionVisible -}}
+      <div
+        class="{{ $footerWidth }} hx-mx-auto hx-flex hx-justify-center hx-py-12 hx-pl-[max(env(safe-area-inset-left),1.5rem)] hx-pr-[max(env(safe-area-inset-right),1.5rem)] hx-text-gray-600 dark:hx-text-gray-400 md:hx-justify-start"
+      >
+        <div class="hx-flex hx-w-full hx-flex-col hx-items-center sm:hx-items-start">
+            {{- if .Site.Params.footer.displayCopyright }}<div class="hx-mt-6 hx-text-xs">{{ $copyright | markdownify }} | <a href="/licenses">Licenses</a></div>{{- end -}}
+        </div>
+      </div>
+    {{- end -}}
+</footer>


### PR DESCRIPTION
Fixes #46 

Add a licenses page and the appropriate attribution and license for each of the board images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a dedicated "Licenses" page with documentation on Creative Commons licenses for Arduino and Raspberry Pi board images
	- Enhanced footer with configurable switches for language and theme toggle options

- **Documentation**
	- Introduced comprehensive license information for documentation content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->